### PR TITLE
Ignore mypy_cache and virtual environments in dir

### DIFF
--- a/docassemblecli/commands.py
+++ b/docassemblecli/commands.py
@@ -162,7 +162,7 @@ def dainstall():
     archive = tempfile.NamedTemporaryFile(suffix=".zip")
     zf = zipfile.ZipFile(archive, mode='w')
     for root, dirs, files in os.walk(args.directory, topdown=True):
-        dirs[:] = [d for d in dirs if d not in ['.git', '__pycache__'] and not d.endswith('.egg-info')]
+        dirs[:] = [d for d in dirs if d not in ['.git', '__pycache__', '.mypy_cache', '.venv'] and not d.endswith('.egg-info')]
         for file in files:
             if file.endswith('~') or file.endswith('.pyc') or file.startswith('#') or file.startswith('.#') or file == '.gitignore':
                 continue


### PR DESCRIPTION
Adds to list of hardcoded directories to ignore. `.mypy_cache` is always created by running the `mypy` tool. Virtual envs aren't always named `.venv`, but it's a convention (also used by mypy I think: mypy won't check the types of code in directories named `.venv`). 