### PR TITLE
Ignore .history directory (created by VS Code)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 *.egg-info
 dist
 newversion.sh
+.history

--- a/docassemblecli/commands.py
+++ b/docassemblecli/commands.py
@@ -174,7 +174,7 @@ def dainstall():
     archive = tempfile.NamedTemporaryFile(suffix=".zip")
     zf = zipfile.ZipFile(archive, mode='w')
     for root, dirs, files in os.walk(args.directory, topdown=True):
-        dirs[:] = [d for d in dirs if d not in ['.git', '__pycache__', '.mypy_cache', '.venv'] and not d.endswith('.egg-info')]
+        dirs[:] = [d for d in dirs if d not in ['.git', '__pycache__', '.mypy_cache', '.venv', '.history'] and not d.endswith('.egg-info')]
         for file in files:
             if file.endswith('~') or file.endswith('.pyc') or file.startswith('#') or file.startswith('.#') or file == '.gitignore':
                 continue


### PR DESCRIPTION
Adds `.history` directory to the ignore list. Currently, if you are in the middle of editing a package with VS Code, several shadow files will be uploaded along with the actual files. I'm not sure yet why the .zip package ends up merging the .history directory with the real directory, but this resolves that.

Usually this is just a minor inconvenience with extra files in the playground, but if you are editing a Flask endpoint, current behavior results in stale endpoints (docassemble "pre-loads" one of the older versions of the .py file), making it cumbersome to test changes.

A longer term fix might be to parse and respect the contents of the .gitignore file, but this resolves a problem for a common editor.