### PR TITLE
Zip things sent to the server by default

### DIFF
--- a/docassemblecli/commands.py
+++ b/docassemblecli/commands.py
@@ -175,7 +175,7 @@ def dainstall():
     if args.norestart:
         data['restart'] = '0'
     archive = tempfile.NamedTemporaryFile(suffix=".zip")
-    zf = zipfile.ZipFile(archive, mode='w')
+    zf = zipfile.ZipFile(archive, compression=zipfile.ZIP_DEFLATED, mode='w')
     args.directory = re.sub(r'/$', '', args.directory)
     for root, dirs, files in os.walk(args.directory, topdown=True):
         dirs[:] = [d for d in dirs if d not in ['.git', '__pycache__', '.mypy_cache', '.venv', '.history'] and not d.endswith('.egg-info')]


### PR DESCRIPTION
I knew that docassemblecli used the python `ZipFile` class to send a zipped file of the package folder to docassemble, but I didn't realize until today that [ZipFile's default compression is `ZIP_STORED`](https://docs.python.org/3/library/zipfile.html#zipfile.ZIP_STORED), i.e. not actually compressed.

This PR makes the default `ZIP_DEFLATED`, which is the most widely used and compatible compression used by zipfiles. This lets us upload packages that would normally be too large for docassemble.

I've been using this today in my regular workflow, and haven't experienced any problems. It does require [zlib](https://docs.python.org/3/library/zlib.html#module-zlib), and I'm not sure how that's packaged on other systems outside Linux. Given that the README instructions point to WSL for running in Windows, this feels fine to merge.